### PR TITLE
Adicionado a Extensão (GD) para o PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Dependências
 * Extensões PHP
  * [DOMDocument](http://br2.php.net/manual/en/domdocument.construct.php)
  * [cURL](http://br2.php.net/manual/book.curl.php)
+ * [GD] (http://php.net/manual/pt_BR/book.image.php)
 
 ------
 


### PR DESCRIPTION
Usando o Ubuntu precisei instalar no PHP o GD para que funciona-se a impressão mo código de barras, então achei importante mencionar isso no README.md como extensão para o PHP.
