### PR TITLE
Adicionados os testes para a consulta das configuracoes das UFs

### DIFF
--- a/exemplos/envelope-consulta-config-uf.xml
+++ b/exemplos/envelope-consulta-config-uf.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope" xmlns:gnr="http://www.gnre.pe.gov.br/webservice/GnreConfigUF">
+    <soap12:Header>
+        <gnr:gnreCabecMsg>
+            <gnr:versaoDados>1.00</gnr:versaoDados>
+        </gnr:gnreCabecMsg>
+    </soap12:Header>
+    <soap12:Body>
+        <gnr:gnreDadosMsg>
+            <TConsultaConfigUf xmlns="http://www.gnre.pe.gov.br">
+                <ambiente>1</ambiente>
+                <uf>PR</uf>
+                <receita>100099</receita>
+            </TConsultaConfigUf>
+        </gnr:gnreDadosMsg>
+    </soap12:Body>
+</soap12:Envelope>

--- a/testes/Sefaz/ConfigUfTest.php
+++ b/testes/Sefaz/ConfigUfTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @covers Sped\Gnre\Sefaz\ConfigUf
+ */
+class ConfigUfTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testDeveRetornarOsCabecalhosParaArequisicaoSoap()
+    {
+        $consulta = new Sped\Gnre\Sefaz\ConfigUf();
+        $headersArray = $consulta->getHeaderSoap();
+
+        $this->assertEquals('Content-Type: application/soap+xml;charset=utf-8;action="http://www.gnre.pe.gov.br/webservice/GnreConfigUF"', $headersArray[0]);
+        $this->assertEquals('SOAPAction: consultar', $headersArray[1]);
+    }
+
+    public function testDeveRetornarOsCabecalhosParaArequisicaoSoapAoWebserviceDeTestes()
+    {
+        $consulta = new Sped\Gnre\Sefaz\ConfigUf();
+        $consulta->utilizarAmbienteDeTeste(true);
+
+        $headersArray = $consulta->getHeaderSoap();
+
+        $this->assertEquals('Content-Type: application/soap+xml;charset=utf-8;action="http://www.testegnre.pe.gov.br/webservice/GnreConfigUF"', $headersArray[0]);
+        $this->assertEquals('SOAPAction: consultar', $headersArray[1]);
+    }
+
+    public function testDeveRetornarAacaoAserExecutadaNoSoap()
+    {
+        $consulta = new Sped\Gnre\Sefaz\ConfigUf();
+
+        $this->assertEquals('https://www.gnre.pe.gov.br/gnreWS/services/GnreConfigUF', $consulta->soapAction());
+    }
+
+    public function testDeveRetornarXmlCompletoVazioParaRealizarAconsulta()
+    {
+        $dadosParaConsulta = file_get_contents(__DIR__ . '/../../exemplos/envelope-consulta-config-uf.xml');
+        
+        $consulta = new Sped\Gnre\Sefaz\ConfigUf();
+        $consulta->setEnvironment(1);
+        $consulta->setEstado('PR');
+        $consulta->setReceita(100099);
+
+        $this->assertXmlStringEqualsXmlString($dadosParaConsulta, $consulta->toXml());
+    }
+
+    public function testDeveRetornarAactionAserExecutadaNoWebServiceDeProducao()
+    {
+        $consulta = new Sped\Gnre\Sefaz\ConfigUf();
+
+        $this->assertEquals($consulta->soapAction(), 'https://www.gnre.pe.gov.br/gnreWS/services/GnreConfigUF');
+    }
+
+    public function testDeveRetornarAactionAserExecutadaNoWebServiceDeTestes()
+    {
+        $consulta = new Sped\Gnre\Sefaz\ConfigUf();
+        $consulta->utilizarAmbienteDeTeste(true);
+
+        $this->assertEquals($consulta->soapAction(), 'https://www.testegnre.pe.gov.br/gnreWS/services/GnreConfigUF');
+    }
+    
+}

--- a/testes/Sefaz/ConsultaConfigUfTest.php
+++ b/testes/Sefaz/ConsultaConfigUfTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Sped\Gnre\Sefaz\Test;
+
+use Sped\Gnre\Sefaz\boolen;
+use Sped\Gnre\Sefaz\ConsultaConfigUf;
+
+/**
+ * @covers Sped\Gnre\Sefaz\ConsultaConfigUf
+ */
+class ConsultaConfigUfTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testDeveDefinirAreceitaParaSerUtilizada()
+    {
+        $gnreConsulta = new MinhaConsultaConfigUf();
+        $this->assertNull($gnreConsulta->setReceita(100099));
+    }
+
+    public function testDeveRetornarAreceitaDefinida()
+    {
+        $gnreConsulta = new MinhaConsultaConfigUf();
+        $gnreConsulta->setReceita(100099);
+
+        $this->assertEquals(100099, $gnreConsulta->getReceita());
+    }
+
+    public function testDeveDefinirOestadoParaSerUtilizado()
+    {
+        $gnreConsulta = new MinhaConsultaConfigUf();
+        $this->assertNull($gnreConsulta->setEstado('PR'));
+    }
+
+    public function testDeveRetornarOestadoDefinido()
+    {
+        $gnreConsulta = new MinhaConsultaConfigUf();
+        $gnreConsulta->setEstado('PR');
+
+        $this->assertEquals('PR', $gnreConsulta->getEstado());
+    }
+
+    public function testDeveDefinirOambienteParaSerUtilizado()
+    {
+        $gnreConsulta = new MinhaConsultaConfigUf();
+        $this->assertNull($gnreConsulta->setEnvironment(1));
+    }
+
+    public function testDeveRetornarOambienteDefinido()
+    {
+        $gnreConsulta = new MinhaConsultaConfigUf();
+        $gnreConsulta->setEnvironment(1);
+
+        $this->assertEquals(1, $gnreConsulta->getEnvironment());
+    }
+
+}
+
+class MinhaConsultaConfigUf extends ConsultaConfigUf
+{
+
+    public function getHeaderSoap()
+    {
+        
+    }
+
+    public function soapAction()
+    {
+        
+    }
+
+    public function toXml()
+    {
+        
+    }
+
+    public function getSoapEnvelop($noRaiz, $conteudoEnvelope)
+    {
+
+    }
+
+    public function utilizarAmbienteDeTeste($ambiente = false)
+    {
+
+    }
+}


### PR DESCRIPTION
Durante os testes encontrei a seguinte mensagem no meu PHPUnit, porém como não diz respeito aos testes implementados nesse pull request, eu deixo para corrigir em outro pull request futuramente:

1) Sped\Gnre\Render\Test\PdfTest::testDeveCriarOpdfApartirDoHtml
Trying to configure method "getDomPdf" which cannot be configured because it does not exist, has not been specified, is final, or is static