### PR TITLE
Permite campos extras para AC

### DIFF
--- a/lib/Sped/Gnre/Sefaz/Estados/AC.php
+++ b/lib/Sped/Gnre/Sefaz/Estados/AC.php
@@ -7,15 +7,4 @@ use Sped\Gnre\Sefaz\Guia;
 class AC extends Padrao
 {
 
-
-    /**
-     * Estado do Acre não possui campos extras. Com esse método mesmo que
-     * seja informado qualquer campo extra na $gnreGuia não vamos adicionar
-     * no XML
-     * {@inheritdoc}
-     */
-    public function getNodeCamposExtras(\DOMDocument $gnre, Guia $gnreGuia)
-    {
-        return null;
-    }
 }


### PR DESCRIPTION
Pode ser necessário para o estado do Acre o envio de campos extras(como mostrado na imagem abaixo), o qual estava sendo bloqueado.

![](https://lh3.googleusercontent.com/-pFKkOEkWXWA/XZ8kZZS3vMI/AAAAAAAACng/T0fFjtML6Z82zmUbjTaf2qBLs-OX4OBIACK8BGAsYHg/s0/2019-10-10.png)
