### PR TITLE
Adicionada verificação para campos opcionais

### DIFF
--- a/lib/Sped/Gnre/Sefaz/Lote.php
+++ b/lib/Sped/Gnre/Sefaz/Lote.php
@@ -140,8 +140,12 @@ class Lote extends LoteGnre
             $c18 = $gnre->createElement('c18_enderecoEmitente', $gnreGuia->c18_enderecoEmitente);
             $c19 = $gnre->createElement('c19_municipioEmitente', $gnreGuia->c19_municipioEmitente);
             $c20 = $gnre->createElement('c20_ufEnderecoEmitente', $gnreGuia->c20_ufEnderecoEmitente);
-            $c21 = $gnre->createElement('c21_cepEmitente', $gnreGuia->c21_cepEmitente);
-            $c22 = $gnre->createElement('c22_telefoneEmitente', $gnreGuia->c22_telefoneEmitente);
+            if ($gnreGuia->c21_cepEmitente) {
+                $c21 = $gnre->createElement('c21_cepEmitente', $gnreGuia->c21_cepEmitente);
+            }
+            if ($gnreGuia->c22_telefoneEmitente) {
+                $c22 = $gnre->createElement('c22_telefoneEmitente', $gnreGuia->c22_telefoneEmitente);
+            }
 
             $c34_tipoIdentificacaoDestinatario = $gnreGuia->c34_tipoIdentificacaoDestinatario;
             $c34 = $gnre->createElement('c34_tipoIdentificacaoDestinatario', $c34_tipoIdentificacaoDestinatario);
@@ -188,8 +192,12 @@ class Lote extends LoteGnre
             $dados->appendChild($c18);
             $dados->appendChild($c19);
             $dados->appendChild($c20);
-            $dados->appendChild($c21);
-            $dados->appendChild($c22);
+            if (isset($c21)) {
+                $dados->appendChild($c21);
+            }
+            if (isset($c22)) {
+                $dados->appendChild($c22);
+            }
             $dados->appendChild($c34);
             $dados->appendChild($c35);
             if ($gnreGuia->c36_inscricaoEstadualDestinatario) {


### PR DESCRIPTION
Os campos de CEP e telefone do emitente são opcionais. Quando eles são enviados em branco o webservice retorna mensagem de erro. Foi feita verificação para incluir no XML somente se o valor dos campos não seja null.

Quando enviei o CEP em branco o webservice retornou mensagem que o campo c21_cepEmitente deve conter 8 caracteres.

### Segundo a documentação

**c21_cepEmitente** - Contém o CEP do contribuinte emitente com 8 dígitos. Digitar apenas números. Esse campo não é obrigatório. No caso da identificação do contribuinte ser por inscrição estadual, esse campo e sua tag poderão ser omitidos.

**c22_telefoneEmitente** - Contém o telefone do contribuinte emitente. Colocar o DDD e o número do telefone. Digitar apenas números. Esse campo não é obrigatório. No caso de não ter essa informação, esse campo e sua tag poderão ser omitidos.
Exemplo:
<c22_telefoneEmitente>1122222222</c22_telefoneEmitente>
Onde: 11 => DDD e 22222222 => Telefone
