### PR TITLE
Campos opcionais estavam sendo enviados no webservice

### DIFF
--- a/lib/Sped/Gnre/Sefaz/Estados/Padrao.php
+++ b/lib/Sped/Gnre/Sefaz/Estados/Padrao.php
@@ -64,15 +64,23 @@ abstract class Padrao
 
         $c05 = $gnre->createElement('c05_referencia');
 
-        $periodo = $gnre->createElement('periodo', $gnreGuia->periodo);
+        if ($gnreGuia->periodo) {
+            $periodo = $gnre->createElement('periodo', $gnreGuia->periodo);
+        }
         $mes = $gnre->createElement('mes', $gnreGuia->mes);
         $ano = $gnre->createElement('ano', $gnreGuia->ano);
-        $parcela = $gnre->createElement('parcela', $gnreGuia->parcela);
+        if ($gnreGuia->parcela) {
+            $parcela = $gnre->createElement('parcela', $gnreGuia->parcela);
+        }
 
-        $c05->appendChild($periodo);
+        if (isset($periodo)) {
+            $c05->appendChild($periodo);
+        }
         $c05->appendChild($mes);
         $c05->appendChild($ano);
-        $c05->appendChild($parcela);
+        if (isset($parcela)) {
+            $c05->appendChild($parcela);
+        }
 
         return $c05;
     }

--- a/lib/Sped/Gnre/Sefaz/Lote.php
+++ b/lib/Sped/Gnre/Sefaz/Lote.php
@@ -218,7 +218,7 @@ class Lote extends LoteGnre
             if ($gnreGuia->c37_razaoSocialDestinatario) {
                 $dados->appendChild($c37);
             }
-            if ($c36_inscricaoEstadualDestinatario) {
+            if ($gnreGuia->c38_municipioDestinatario) {
                 $dados->appendChild($c38);
             }
             $dados->appendChild($c33);

--- a/lib/Sped/Gnre/Sefaz/Lote.php
+++ b/lib/Sped/Gnre/Sefaz/Lote.php
@@ -206,15 +206,21 @@ class Lote extends LoteGnre
             if (isset($c22)) {
                 $dados->appendChild($c22);
             }
-            $dados->appendChild($c34);
-            $dados->appendChild($c35);
+            if ($c34_tipoIdentificacaoDestinatario) {
+                $dados->appendChild($c34);
+            }
+            if ($c35_idContribuinteDestinatario) {
+                $dados->appendChild($c35);
+            }
             if ($gnreGuia->c36_inscricaoEstadualDestinatario) {
                 $dados->appendChild($c36);
             }
             if ($gnreGuia->c37_razaoSocialDestinatario) {
                 $dados->appendChild($c37);
             }
-            $dados->appendChild($c38);
+            if ($c36_inscricaoEstadualDestinatario) {
+                $dados->appendChild($c38);
+            }
             $dados->appendChild($c33);
 
             $c05 = $guiaEstado->getNodeReferencia($gnre, $gnreGuia);

--- a/lib/Sped/Gnre/Sefaz/Lote.php
+++ b/lib/Sped/Gnre/Sefaz/Lote.php
@@ -129,8 +129,12 @@ class Lote extends LoteGnre
 
             $c28 = $gnre->createElement('c28_tipoDocOrigem', $gnreGuia->c28_tipoDocOrigem);
             $c04 = $gnre->createElement('c04_docOrigem', $gnreGuia->c04_docOrigem);
-            $c06 = $gnre->createElement('c06_valorPrincipal', $gnreGuia->c06_valorPrincipal);
-            $c10 = $gnre->createElement('c10_valorTotal', $gnreGuia->c10_valorTotal);
+            if ($gnreGuia->c06_valorPrincipal) {
+                $c06 = $gnre->createElement('c06_valorPrincipal', $gnreGuia->c06_valorPrincipal);
+            }
+            if ($gnreGuia->c10_valorTotal) {
+                $c10 = $gnre->createElement('c10_valorTotal', $gnreGuia->c10_valorTotal);
+            }
             $c14 = $gnre->createElement('c14_dataVencimento', $gnreGuia->c14_dataVencimento);
             $c15 = $gnre->createElement('c15_convenio', $gnreGuia->c15_convenio);
             $c16 = $gnre->createElement('c16_razaoSocialEmitente', $gnreGuia->c16_razaoSocialEmitente);
@@ -179,8 +183,12 @@ class Lote extends LoteGnre
             $dados->appendChild($c03);
             $dados->appendChild($c28);
             $dados->appendChild($c04);
-            $dados->appendChild($c06);
-            $dados->appendChild($c10);
+            if (isset($c06)) {
+                $dados->appendChild($c06);
+            }
+            if (isset($c10)) {
+                $dados->appendChild($c10);
+            }
             $dados->appendChild($c14);
             if ($gnreGuia->c15_convenio) {
                 $dados->appendChild($c15);


### PR DESCRIPTION
Alguns campos estão sendo enviados para a Sefaz com o valor nulo e o webservice retorna erro, informando que o valor do campo não é válido. Foram feitas verificações nos campos encontrados para não serem inclusos no XML quando o campo é nulo.

O erro ocorre quando o campo não é obrigatório, portanto, não é informado valor para a emissão da guia.