### PR TITLE
fix: corrige erro de dependência do Zen

### DIFF
--- a/exemplos/gerar-codigo-de-barras.php
+++ b/exemplos/gerar-codigo-de-barras.php
@@ -6,10 +6,10 @@ ob_start();
 $text = '91910919190191091090109109190109';
 
 $options = array('text' => (string) $text, 'barHeight' => 40, 'barWidth' => 100, 'imageType' => 'jpeg');
-$barcode = new \Zend\Barcode\Object\Code128();
+$barcode = new \Laminas\Barcode\Object\Code128();
 $barcode->setOptions($options);
 
-$barcodeOBj = \Zend\Barcode\Barcode::factory($barcode);
+$barcodeOBj = \Laminas\Barcode\Barcode::factory($barcode);
 
 $imageResource = $barcodeOBj->draw();
 

--- a/lib/Sped/Gnre/Render/Barcode128.php
+++ b/lib/Sped/Gnre/Render/Barcode128.php
@@ -70,10 +70,10 @@ class Barcode128
             'drawText' => false
         );
 
-        $barcode = new \Zend\Barcode\Object\Code128();
+        $barcode = new \Laminas\Barcode\Object\Code128();
         $barcode->setOptions($options);
 
-        $barcodeOBj = \Zend\Barcode\Barcode::factory($barcode);
+        $barcodeOBj = \Laminas\Barcode\Barcode::factory($barcode);
 
         $imageResource = $barcodeOBj->draw();
 


### PR DESCRIPTION
**Problema:**
Tentei importar o pacote em um projeto novo zerado. Notei que ocorre um conflito entre o zen e o laminas. 
Isso impede a criação do barcode128 o que implica na não impressão correta da guia.

`            "conflict": {
                "zendframework/zend-barcode": "*"
            },
`



**Como replicar:**
A) Instalar o projeto como dependência de outro.
B) Copiar o projeto, remover o composer.lock e dar um composer update, o que 'emularia ' a instalação do mesmo como dependência, sem pacotes antigos instalados.

- Gerar um pdf (ou um html) de uma guia com código de barras. 

- Feito isso teremos o seguinte erro: 
![image](https://user-images.githubusercontent.com/66074971/157647998-a017d719-e916-4bd5-b295-d092146abd36.png)


**Solução:**

Lendo a documentação do zend-barcode os mesmos recomendam utilizar o laminas
![image](https://user-images.githubusercontent.com/66074971/157649033-7db657a8-bdaf-4f78-a687-e8d8bce3940f.png)
Logo sendo apenas alterado o pacote utilizado de "Zend" para "Laminas" a guia volta a ser gerada em projetos novos (que não tenham o composer.lock novo)

![image](https://user-images.githubusercontent.com/66074971/157649315-51548fd1-d70a-473a-b713-e0123011aae5.png)
