### PR TITLE
fix: corrige divisao de mes por ano

### DIFF
--- a/templates/gnre.tpl
+++ b/templates/gnre.tpl
@@ -1,7 +1,7 @@
 <html>
     <meta charset="UTF-8"/>
     <style type="text/css">
-        @page { 
+        @page {
             margin: 5px;
             padding:0px;
         }
@@ -197,7 +197,7 @@
                                 <td class="nobottom" align="left">Nº Parcela</td>
                             </tr>
                             <tr>
-                                <td colspan="2" class="notop" align="right">{$guia->mes / $guia->ano}</td>
+                                <td colspan="2" class="notop" align="right">{$guia->mes}/{$guia->ano}</td>
                                 <td class="notop" align="right">{$guia->parcela}</td>
                             </tr>
                             <tr>


### PR DESCRIPTION
a expressão  ` <td colspan="2" class="notop" align="right">{$guia->mes / $guia->ano}</td>` constante no template trazia um float que resultava da divisão do mês pelo ano. 

Alterado o layout de maneira que imprima no formato "mes / ano"