### PR TITLE
fix: altera versaoDados do soap

### DIFF
--- a/lib/Sped/Gnre/Sefaz/Consulta.php
+++ b/lib/Sped/Gnre/Sefaz/Consulta.php
@@ -96,7 +96,7 @@ class Consulta extends ConsultaGnre
 
         $gnreCabecalhoSoap = $gnre->createElement('gnreCabecMsg');
         $gnreCabecalhoSoap->setAttribute('xmlns', 'http://www.gnre.pe.gov.br/wsdl/consultar');
-        $gnreCabecalhoSoap->appendChild($gnre->createElement('versaoDados', '1.00'));
+        $gnreCabecalhoSoap->appendChild($gnre->createElement('versaoDados', '2.00'));
 
         $soapHeader = $gnre->createElement('soap12:Header');
         $soapHeader->appendChild($gnreCabecalhoSoap);


### PR DESCRIPTION
Ao efetuar a consulta usando o framework se tem o seguinte retorno:

```
<?xml version="1.0" encoding="utf-8"?>
<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
	<soapenv:Body>
		<gnreRespostaMsg xmlns="http://www.gnre.pe.gov.br/webservice/GnreResultadoLote">
			<ns1:TResultLote_GNRE xmlns="http://www.gnre.pe.gov.br" xmlns:ns1="http://www.gnre.pe.gov.br">
				<ns1:ambiente>1</ns1:ambiente>
				<ns1:numeroRecibo>**********</ns1:numeroRecibo>
				<ns1:situacaoProcess>
					<ns1:codigo>303</ns1:codigo>
					<ns1:descricao>Vers&#xE3;o dos Dados n&#xE3;o suportada</ns1:descricao>
				</ns1:situacaoProcess>
			</ns1:TResultLote_GNRE>
		</gnreRespostaMsg>
	</soapenv:Body>
</soapenv:Envelope>

```

Alterando a tag de 1.00 para 2.00 o retorno passa a funcionar normalmente. 