### PR TITLE
Classe GnreHelper

### DIFF
--- a/lib/Sped/Gnre/Helper/GnreHelper.php
+++ b/lib/Sped/Gnre/Helper/GnreHelper.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Este arquivo é parte do programa GNRE PHP
+ * GNRE PHP é um software livre; você pode redistribuí-lo e/ou
+ * modificá-lo dentro dos termos da Licença Pública Geral GNU como
+ * abstractada pela Fundação do Software Livre (FSF); na versão 2 da
+ * Licença, ou (na sua opinião) qualquer versão.
+ * Este programa é distribuído na esperança de que possa ser  útil,
+ * mas SEM NENHUMA GARANTIA; sem uma garantia implícita de ADEQUAÇÃO a qualquer
+ * MERCADO ou APLICAÇÃO EM PARTICULAR. Veja a
+ * Licença Pública Geral GNU para maiores detalhes.
+ * Você deve ter recebido uma cópia da Licença Pública Geral GNU
+ * junto com este programa, se não, escreva para a Fundação do Software
+ * Livre(FSF) Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+namespace Sped\Gnre\Helper;
+
+
+use Sped\Gnre\Sefaz\Guia;
+use \stdClass;
+
+/**
+ * Classe abstrata que utiliza o padrão de projeto Template Method para
+ * setar as regras de leitura do retorno da SEFAZ
+ *
+ * @package     gnre
+ * @author      Luiz Kim <luiz.kim@controleonline.com>
+ * @license     http://www.gnu.org/licenses/gpl-howto.html GPL
+ * @link        http://en.wikipedia.org/wiki/Template_method_pattern Template Method Design Pattern
+ * @version     1.0.0
+ */
+class GnreHelper
+{
+
+    protected static $xmlNf;
+
+
+    public function __construct($xmlNf)
+    {
+    }
+
+    /**
+     * Método utilizado para gerar os dados principais da GNRE utilizando os dados encontrados dentro do XML
+     * 
+     *
+     * @param string $dadosArquivo <p>String contendo o xml da NF de venda
+     * utilizada no SEFAZ</p>
+     * @since 1.0.0
+     */
+    public static function getGuiaGnre($xmlNf): Guia
+    {
+        $xml = self::parseNf($xmlNf);
+
+        $guia = new Guia();
+        
+        $guia->c04_docOrigem = $xml->NrNf;
+        $guia->c28_tipoDocOrigem = $xml->TipoDoc;        
+        $guia->c21_cepEmitente = $xml->CEPEmpresa;
+        $guia->c16_razaoSocialEmitente = $xml->NmEmpresa;
+        $guia->c18_enderecoEmitente = $xml->EnderecoEmpresa;
+        $guia->c19_municipioEmitente = $xml->CdMunicipioEmpresa;
+        $guia->c20_ufEnderecoEmitente = $xml->UfEmpresa;
+        $guia->c17_inscricaoEstadualEmitente = $xml->NrIEEmpresa;
+        $guia->c22_telefoneEmitente = $xml->TelefoneEmpresa;
+        $guia->c01_UfFavorecida = $xml->IdUfCliente;
+        $guia->c36_inscricaoEstadualDestinatario = $xml->NrIECliente;
+        $guia->c37_razaoSocialDestinatario = $xml->NmCliente;
+        $guia->c38_municipioDestinatario = $xml->CdMunicipioCliente;
+
+
+        return $guia;
+    }
+
+
+    public static function parseNf($xmlNf): stdClass
+    {
+        $xml = simplexml_load_string($xmlNf);
+        $parsed = new stdClass();
+
+        
+        $parsed->CEPEmpresa = $xml->NFe->infNFe->emit->enderEmit->CEP;
+        $parsed->EnderecoEmpresa = $xml->NFe->infNFe->emit->enderEmit->xLgr;
+        $parsed->CdMunicipioEmpresa = $xml->NFe->infNFe->emit->enderEmit->cMun;
+        $parsed->UfEmpresa = $xml->NFe->infNFe->emit->enderEmit->UF;
+        $parsed->TelefoneEmpresa = $xml->NFe->infNFe->emit->enderEmit->fone;
+        $parsed->NrIEEmpresa = $xml->NFe->infNFe->emit->IE;                
+        $parsed->NmEmpresaCliente = $xml->NFe->infNFe->emit->xNome;
+        $parsed->NrDocumentoCliente = $xml->NFe->infNFe->dest->CNPJ ?: $xml->NFe->infNFe->dest->CPF;
+        $parsed->NrIECliente = $xml->NFe->infNFe->dest->IE;
+        $parsed->NmCliente = $xml->NFe->infNFe->dest->xNome;
+        $parsed->NmCidade = $xml->NFe->infNFe->dest->enderDest->xMun;
+        $parsed->IdUfCliente = $xml->NFe->infNFe->dest->enderDest->UF;
+        $parsed->CdMunicipioCliente = $xml->NFe->infNFe->dest->enderDest->cMun;
+        $parsed->ISUFCliente = $xml->NFe->infNFe->dest->ISUF;        
+        $parsed->TipoDoc = $xml->NFe->infNFe->ide->tpDoc;
+        $parsed->NrChaveNFe = $xml->protNFe->infProt->chNFe;
+        $parsed->VlNf = $xml->NFe->infNFe->total->ICMSTot->vNF;
+        $parsed->NrNf = $xml->NFe->infNFe->ide->nNF;
+
+        return $parsed;
+    }
+}

--- a/lib/Sped/Gnre/Helper/GnreHelper.php
+++ b/lib/Sped/Gnre/Helper/GnreHelper.php
@@ -86,7 +86,7 @@ class GnreHelper
         $parsed->UfEmpresa = $xml->NFe->infNFe->emit->enderEmit->UF;
         $parsed->TelefoneEmpresa = $xml->NFe->infNFe->emit->enderEmit->fone;
         $parsed->NrIEEmpresa = $xml->NFe->infNFe->emit->IE;                
-        $parsed->NmEmpresaCliente = $xml->NFe->infNFe->emit->xNome;
+        $parsed->NmEmpresa = $xml->NFe->infNFe->emit->xNome;
         $parsed->NrDocumentoCliente = $xml->NFe->infNFe->dest->CNPJ ?: $xml->NFe->infNFe->dest->CPF;
         $parsed->NrIECliente = $xml->NFe->infNFe->dest->IE;
         $parsed->NmCliente = $xml->NFe->infNFe->dest->xNome;

--- a/lib/Sped/Gnre/Helper/GnreHelper.php
+++ b/lib/Sped/Gnre/Helper/GnreHelper.php
@@ -51,18 +51,21 @@ class GnreHelper
      */
     public static function getGuiaGnre($xmlNf): Guia
     {
+
         $xml = self::parseNf($xmlNf);
-        $guia = new Guia();        
+        $guia = new Guia();
         $guia->c04_docOrigem = $xml->NrNf;
-        $guia->c28_tipoDocOrigem = $xml->TipoDoc;        
+        $guia->c28_tipoDocOrigem = $xml->TipoDoc;
         $guia->c21_cepEmitente = $xml->CEPEmpresa;
         $guia->c16_razaoSocialEmitente = $xml->NmEmpresa;
+        $guia->c03_idContribuinteEmitente = $xml->NrDocumentoEmpresa;
         $guia->c18_enderecoEmitente = $xml->EnderecoEmpresa;
         $guia->c19_municipioEmitente = $xml->MunicipioEmpresa;
         $guia->c20_ufEnderecoEmitente = $xml->UfEmpresa;
         $guia->c17_inscricaoEstadualEmitente = $xml->NrIEEmpresa;
         $guia->c22_telefoneEmitente = $xml->TelefoneEmpresa;
         $guia->c01_UfFavorecida = $xml->IdUfCliente;
+        $guia->c35_idContribuinteDestinatario = $xml->NrDocumentoCliente;
         $guia->c36_inscricaoEstadualDestinatario = $xml->NrIECliente;
         $guia->c37_razaoSocialDestinatario = $xml->NmCliente;
         $guia->c38_municipioDestinatario = $xml->MunicipioCliente;
@@ -76,24 +79,26 @@ class GnreHelper
         $xml = simplexml_load_string($xmlNf);
         $parsed = new stdClass();
 
-        
+
         $parsed->CEPEmpresa = $xml->NFe->infNFe->emit->enderEmit->CEP;
         $parsed->EnderecoEmpresa = $xml->NFe->infNFe->emit->enderEmit->xLgr;
         $parsed->CdMunicipioEmpresa = $xml->NFe->infNFe->emit->enderEmit->cMun;
-        $parsed->MunicipioEmpresa = $xml->NFe->infNFe->emit->enderEmit->xMun;        
+        $parsed->MunicipioEmpresa = $xml->NFe->infNFe->emit->enderEmit->xMun;
         $parsed->UfEmpresa = $xml->NFe->infNFe->emit->enderEmit->UF;
         $parsed->TelefoneEmpresa = $xml->NFe->infNFe->emit->enderEmit->fone;
-        $parsed->NrIEEmpresa = $xml->NFe->infNFe->emit->IE;                
+        $parsed->NrIEEmpresa = $xml->NFe->infNFe->emit->IE;
         $parsed->NmEmpresa = $xml->NFe->infNFe->emit->xNome;
-        $parsed->NrDocumentoCliente = $xml->NFe->infNFe->dest->CNPJ ?: $xml->NFe->infNFe->dest->CPF;
+        $parsed->NrDocumentoEmpresa = $xml->NFe->infNFe->emit->CNPJ;
 
+
+        $parsed->NrDocumentoCliente = $xml->NFe->infNFe->dest->CNPJ ?: $xml->NFe->infNFe->dest->CPF;
         $parsed->NrIECliente = $xml->NFe->infNFe->dest->IE;
         $parsed->NmCliente = $xml->NFe->infNFe->dest->xNome;
         $parsed->NmCidade = $xml->NFe->infNFe->dest->enderDest->xMun;
         $parsed->IdUfCliente = $xml->NFe->infNFe->dest->enderDest->UF;
         $parsed->CdMunicipioCliente = $xml->NFe->infNFe->dest->enderDest->cMun;
         $parsed->MunicipioCliente = $xml->NFe->infNFe->dest->enderDest->xMun;
-        $parsed->ISUFCliente = $xml->NFe->infNFe->dest->ISUF;        
+        $parsed->ISUFCliente = $xml->NFe->infNFe->dest->ISUF;
         $parsed->TipoDoc = $xml->NFe->infNFe->ide->tpDoc;
         $parsed->NrChaveNFe = $xml->protNFe->infProt->chNFe;
         $parsed->VlNf = $xml->NFe->infNFe->total->ICMSTot->vNF;

--- a/lib/Sped/Gnre/Helper/GnreHelper.php
+++ b/lib/Sped/Gnre/Helper/GnreHelper.php
@@ -52,23 +52,20 @@ class GnreHelper
     public static function getGuiaGnre($xmlNf): Guia
     {
         $xml = self::parseNf($xmlNf);
-
-        $guia = new Guia();
-        
+        $guia = new Guia();        
         $guia->c04_docOrigem = $xml->NrNf;
         $guia->c28_tipoDocOrigem = $xml->TipoDoc;        
         $guia->c21_cepEmitente = $xml->CEPEmpresa;
         $guia->c16_razaoSocialEmitente = $xml->NmEmpresa;
         $guia->c18_enderecoEmitente = $xml->EnderecoEmpresa;
-        $guia->c19_municipioEmitente = $xml->CdMunicipioEmpresa;
+        $guia->c19_municipioEmitente = $xml->MunicipioEmpresa;
         $guia->c20_ufEnderecoEmitente = $xml->UfEmpresa;
         $guia->c17_inscricaoEstadualEmitente = $xml->NrIEEmpresa;
         $guia->c22_telefoneEmitente = $xml->TelefoneEmpresa;
         $guia->c01_UfFavorecida = $xml->IdUfCliente;
         $guia->c36_inscricaoEstadualDestinatario = $xml->NrIECliente;
         $guia->c37_razaoSocialDestinatario = $xml->NmCliente;
-        $guia->c38_municipioDestinatario = $xml->CdMunicipioCliente;
-
+        $guia->c38_municipioDestinatario = $xml->MunicipioCliente;
 
         return $guia;
     }
@@ -83,16 +80,19 @@ class GnreHelper
         $parsed->CEPEmpresa = $xml->NFe->infNFe->emit->enderEmit->CEP;
         $parsed->EnderecoEmpresa = $xml->NFe->infNFe->emit->enderEmit->xLgr;
         $parsed->CdMunicipioEmpresa = $xml->NFe->infNFe->emit->enderEmit->cMun;
+        $parsed->MunicipioEmpresa = $xml->NFe->infNFe->emit->enderEmit->xMun;        
         $parsed->UfEmpresa = $xml->NFe->infNFe->emit->enderEmit->UF;
         $parsed->TelefoneEmpresa = $xml->NFe->infNFe->emit->enderEmit->fone;
         $parsed->NrIEEmpresa = $xml->NFe->infNFe->emit->IE;                
         $parsed->NmEmpresa = $xml->NFe->infNFe->emit->xNome;
         $parsed->NrDocumentoCliente = $xml->NFe->infNFe->dest->CNPJ ?: $xml->NFe->infNFe->dest->CPF;
+
         $parsed->NrIECliente = $xml->NFe->infNFe->dest->IE;
         $parsed->NmCliente = $xml->NFe->infNFe->dest->xNome;
         $parsed->NmCidade = $xml->NFe->infNFe->dest->enderDest->xMun;
         $parsed->IdUfCliente = $xml->NFe->infNFe->dest->enderDest->UF;
         $parsed->CdMunicipioCliente = $xml->NFe->infNFe->dest->enderDest->cMun;
+        $parsed->MunicipioCliente = $xml->NFe->infNFe->dest->enderDest->xMun;
         $parsed->ISUFCliente = $xml->NFe->infNFe->dest->ISUF;        
         $parsed->TipoDoc = $xml->NFe->infNFe->ide->tpDoc;
         $parsed->NrChaveNFe = $xml->protNFe->infProt->chNFe;


### PR DESCRIPTION
O método getGuiaGnre já preenche todos os dados encontrados em uma NFe através do XMl, reduzindo a quantidade de campos utilizados para criar uma Guia de GNRE. 

Exemplo: 

          ```
            $guia = GnreHelper::getGuiaGnre($xmlString);
            $guia->c27_tipoIdentificacaoEmitente = 1;
            $guia->c03_idContribuinteEmitente = 41819055000105;                                                
            $guia->c34_tipoIdentificacaoDestinatario = 1;
            $guia->c35_idContribuinteDestinatario = 86268158000162;          
            $guia->parcela = 1;
            $guia->mes = date('m');
            $guia->ano = date('Y');
            $guia->periodo = date('Y');
            $guia->c02_receita = $receita->getCdReceita();
            //$guia->c33_dataPagamento = '2015-11-30';      
            //$guia->c15_convenio = 546456;
            //$guia->c25_detalhamentoReceita = 10101010;
            //$guia->c26_produto = 'TESTE DE PROD';
            $guia->c28_tipoDocOrigem = 10;
            $guia->c04_docOrigem = 5656;
            $guia->c06_valorPrincipal = 10.99;
            $guia->c10_valorTotal = 12.52;
            $guia->c14_dataVencimento = '01/05/2015';                            
            $guia->c15_convenio = 546456;
            $lote = new Lote();
            $lote->addGuia($guia);
```